### PR TITLE
Update extensions.yml

### DIFF
--- a/_data/extensions.yml
+++ b/_data/extensions.yml
@@ -169,6 +169,11 @@
       description: Show job logs on the dashboard.
       url: https://github.com/meriturva/Hangfire.Dashboard.JobLogs
       author: meriturva
+    
+    - name: SubPub.Hangfire
+      description: Publishers create Hangfire Jobs for subscribers by broadcasting events
+      url: https://github.com/SitholeWB/SubPub.Hangfire
+      author: sitholewb
 
 - name: Storages
   description: The following community projects allow you to use your favorite technology


### PR DESCRIPTION
This extension lets you create applications with event publishers and subscribers. Publishers communicate LOCALLY with subscribers by broadcasting events, Hangfire will process these events in the background via implemented handlers