### PR TITLE
Add a2n.Hangfire.Dashboard to extensions list

### DIFF
--- a/_data/extensions.yml
+++ b/_data/extensions.yml
@@ -5,6 +5,11 @@
 
 - name: Common
   projects:
+    - name: a2n.Hangfire.Dashboard
+      description: Community dashboard extension with console output, job tags, recurring job CRUD, global search, advanced filters, analytics, and SignalR realtime updates.
+      url: https://github.com/anwarminarso/a2n.Hangfire.Dashboard
+      author: anwarminarso
+
     - name: Hangfire.Community.Dashboard.Heatmap
       description: Adds a visual timeline and heatmap view to Hangfire Dashboard, showing when recurring jobs are scheduled throughout the day.
       url: https://github.com/brodrigz/Hangfire.Community.Dashboard.Heatmap


### PR DESCRIPTION
## Summary
Adds [a2n.Hangfire.Dashboard](https://github.com/anwarminarso/a2n.Hangfire.Dashboard) to the community extensions list under **Common**.
Community-maintained dashboard extension for Hangfire with:
- Console output and job tags (compatible with existing Hangfire.Console / Hangfire.Tags storage)
- Recurring job CRUD from the UI
- Global search and advanced filters
- Analytics (with optional SQL Server / PostgreSQL adapters)
- SignalR realtime updates
NuGet: https://www.nuget.org/packages/a2n.Hangfire.Dashboard